### PR TITLE
Update URLs

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -80,11 +80,10 @@ messages:
     https://github.com/Vyxal/VyxalBotSE/blob/master/instructions.md
   info: >-
     [GitHub Repository](https://github.com/Vyxal/Vyxal/) | [Online
-    Interpreter](https://lyxal.pythonanywhere.com) |
+    Interpreter](https://vyxal.pythonanywhere.com) |
     [Tutorial](https://github.com/Vyxal/Vyxal/blob/master/docs/Tutorial.md) |
     [Vyxapedia](https://vyxapedia.hyper-neutrino.xyz) | [List of
-    elements](https://github.com/Vyxal/Vyxal/blob/master/docs/elements.txt) |
-    [Code Page](https://github.com/Vyxal/Vyxal/blob/master/docs/codepage.txt) |
+    elements](https://github.com/Vyxal/Vyxal/blob/main/documents/knowledge/elements.txt) |
     [GitHub Organization](https://github.com/Vyxal/)
   issue-404: >-
     failed to create the issue (404); make sure you have spelled the repository

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -125,7 +125,7 @@ def execute(flags, code, inputs, header="", footer=""):
 
     session = requests.Session()
 
-    r = session.get("https://lyxal.pythonanywhere.com")
+    r = session.get("https://vyxal.pythonanywhere.com")
     if r.status_code == 200:
         start = r.text.find("<session-code>")
         end = r.text.find("</session-code>")
@@ -139,7 +139,7 @@ def execute(flags, code, inputs, header="", footer=""):
     else:
         return ("", f"[GET /] returned {r.status_code}")
 
-    r = session.post("https://lyxal.pythonanywhere.com/execute", data=payload)
+    r = session.post("https://vyxal.pythonanywhere.com/execute", data=payload)
     if r.status_code == 200:
         try:
             data = r.json()


### PR DESCRIPTION
- Replace `lyxal.pythonanywhere.com` with `vyxal.pythonanywhere.com`
- Update links which pointed to files on `master` (now called `old`) with their counterparts on the new `main` (previously called `fresh-beginnings`)
- There's no codepage.txt file any more, so I removed that link.